### PR TITLE
chore: monorepo the qttest-utils npm module

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This extension allows VSCode to know about [Qt Tests](https://doc.qt.io/qt-6/qtest-overview.html). QtTestLib tests will appear in the side bar, under "Testing".<br>
 The test slots are also exposed and can be run individually.
 
+GTests are also listed, but their individual "slots" are not exposed.
+
 ## Requirements
 
 Only `CMake` based projects are supported at this time. The [cmake extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) is used to determine
@@ -19,12 +21,6 @@ the build directory and `ctest` is invoked to list the available tests, which we
 
 - `KDAB.QtTest.CheckTestLinksToQtTestLib` Only available on Linux. Turn it on in case you have non-Qt tests executables that
 you want to exclude from the list. Patches accepted for Windows and macOS support.
-
-## Future plans
-
-We might try to contribute QtTest support to [C++ TestMate](https://marketplace.visualstudio.com/items?itemName=matepek.vscode-catch2-test-adapter), however, I think it's also fine to keep it as a separate extension, as most of the code is already provided by VSCode, there wouldn't be any code savings by integrating it.
-<br>
-Either way, we've moved the bulk of this extension's code into a separate [nodejs module](https://www.npmjs.com/package/@iamsergio/qttest-utils). That module is reusable and exposes API ready to be used by other test extensions easily.
 
 ## Troubleshooting
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,7 +17,7 @@ export default tseslint.config(
             "@typescript-eslint": tseslint.plugin
         },
         rules: {
-            "@typescript-eslint/naming-convention": "warn",
+            "@typescript-eslint/naming-convention": "off",
             "curly": "warn",
             "eqeqeq": "warn",
             "no-throw-literal": "warn",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
-        "@iamsergio/qttest-utils": "2.6.1",
+        "tap-parser": "^18.3.0",
         "vscode-cmake-tools": "^1.5.0"
       },
       "devDependencies": {
@@ -220,18 +220,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@iamsergio/qttest-utils": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@iamsergio/qttest-utils/-/qttest-utils-2.6.1.tgz",
-      "integrity": "sha512-AV1n6/mNrrnmma0Nnpu47MpXPwiL2A4pnA4cZw2G11KR/b8zREvhpkHUKSm/N1Bl0+R8NnfJIoPVHJK5Wb3S3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "tap-parser": "^18.3.0"
-      },
-      "engines": {
-        "node": ">=22.0.0"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "typescript-eslint": "^8.0.0"
   },
   "dependencies": {
-    "@iamsergio/qttest-utils": "2.6.1",
+    "tap-parser": "^18.3.0",
     "vscode-cmake-tools": "^1.5.0"
   },
   "extensionDependencies": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,13 +14,7 @@ import {
   UIElement,
   Project,
 } from "vscode-cmake-tools";
-import qttest from "@iamsergio/qttest-utils";
-import {
-  QtTest,
-  QtTests,
-  QtTestSlot,
-} from "@iamsergio/qttest-utils/out/qttest";
-import { CMakeTests } from "@iamsergio/qttest-utils/out/cmake";
+import { QtTest, QtTests, QtTestSlot, CMakeTests } from "./qttest-utils";
 
 const DEBUGGER_MS_GDB = "ms-vscode.cpptools gdb";
 const DEBUGGER_MS_LLDB = "ms-vscode.cpptools lldb";

--- a/src/qttest-utils/cmake.ts
+++ b/src/qttest-utils/cmake.ts
@@ -1,0 +1,342 @@
+// SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// Author: Sergio Martins <sergio.martins@kdab.com>
+// SPDX-License-Identifier: MIT
+
+import { spawn } from "child_process";
+import path from "path";
+import { logMessage } from "./qttest";
+import { fstatSync } from "fs";
+
+/**
+ * Represents tests added in cmake (Via add_test())
+ *
+ * Contains methods to discover Qt Tests via CMake
+ */
+export class CMakeTests {
+  // The build dir where we'll run
+  readonly buildDirPath: string;
+
+  constructor(buildDirPath: string) {
+    this.buildDirPath = buildDirPath;
+  }
+
+  /**
+   * Invokes ctest.exe --show-only=json-v1
+   *
+   * @returns a promise with the list of tests
+   */
+  public async tests(): Promise<CMakeTest[] | undefined> {
+    // TODO: Check if folder exists
+    if (this.buildDirPath.length === 0) {
+      console.error("Could not find out cmake build dir");
+      return undefined;
+    }
+
+    return new Promise((resolve, reject) => {
+      logMessage(
+        "Running ctest --show-only=json-v1 with cwd=" + this.buildDirPath,
+      );
+      const child = spawn("ctest", ["--show-only=json-v1"], {
+        cwd: this.buildDirPath,
+      });
+      let output = "";
+      child.stdout.on("data", (chunk) => {
+        output += chunk.toString();
+      });
+
+      child.on("close", (code) => {
+        if (code === 0) {
+          if (output.length === 0) {
+            console.error(
+              "ctestJsonToList: Empty json output. Command was ctest --show-only=json-v1 , in " +
+                this.buildDirPath,
+            );
+            reject(new Error("Failed to get ctest JSON output"));
+          } else {
+            resolve(this.ctestJsonToList(output));
+          }
+        } else {
+          reject(new Error("Failed to run ctest"));
+        }
+      });
+
+      return undefined;
+    });
+  }
+
+  private ctestJsonToList(json: string): CMakeTest[] {
+    let allJSON = JSON.parse(json);
+
+    if (!("tests" in allJSON)) {
+      return [];
+    }
+
+    let tests: CMakeTest[] = allJSON.tests.map((testJSON: any) => {
+      let test = new CMakeTest();
+      test.command = testJSON.command;
+      test.cwd = testJSON.cwd;
+
+      // Extract environment information if present in ctest JSON.
+      // ctest may expose environment as `environment` (string or array),
+      // or embed it into `properties` either as an object or array.
+      try {
+        let envArr: string[] | undefined = undefined;
+
+        if (testJSON.environment) {
+          envArr = Array.isArray(testJSON.environment)
+            ? testJSON.environment
+            : [testJSON.environment];
+        }
+
+        if (!envArr && testJSON.properties) {
+          const props = testJSON.properties;
+
+          // properties might be an object with ENVIRONMENT key or an array of {name,value} entries
+          if (!Array.isArray(props) && props.ENVIRONMENT) {
+            const val = props.ENVIRONMENT;
+            if (typeof val === "string") {
+              envArr = [val];
+            } else if (Array.isArray(val)) {
+              envArr = val;
+            }
+          } else if (Array.isArray(props)) {
+            for (const p of props) {
+              if (!p || !p.name) {
+                continue;
+              }
+              if (p.name === "ENVIRONMENT" || p.name === "Environment") {
+                const v = p.value;
+                if (typeof v === "string") {
+                  envArr = [v];
+                } else if (Array.isArray(v)) {
+                  envArr = v;
+                }
+                break;
+              }
+            }
+          }
+        }
+
+        if (envArr) {
+          test.environment = envArr;
+        }
+      } catch (e) {
+        try {
+          logMessage(
+            "ctest: failed to parse environment for test: " +
+              JSON.stringify(testJSON) +
+              " error: " +
+              e,
+          );
+        } catch (_) {}
+      }
+
+      return test;
+    });
+
+    // filter invalid tests:
+    tests = tests.filter((test) => {
+      // pretty print test
+      if (!test.command || test.command.length === 0) {
+        return false;
+      }
+
+      let testExecutablePath = test.executablePath();
+      let baseName = path.basename(testExecutablePath).toLowerCase();
+      if (baseName.endsWith(".exe")) {
+        baseName = baseName.substring(0, baseName.length - 4);
+      }
+
+      // People doing complicated things in add_test()
+      if (baseName === "ctest" || baseName === "cmake") {
+        return false;
+      }
+
+      return true;
+    });
+
+    return tests;
+  }
+
+  /// Returns the cmake target name for the specified executable
+  /// codemodel should have a "projects" key at root.
+  public targetNameForExecutable(
+    executable: string,
+    codemodel: any,
+    workaround: boolean = false,
+  ): string | undefined {
+    let projects = codemodel["projects"];
+    if (!projects) {
+      return undefined;
+    }
+
+    for (let project of projects) {
+      let targets = project["targets"];
+      if (!targets) {
+        continue;
+      }
+
+      for (let target of targets) {
+        let artifacts = target["artifacts"];
+        if (!artifacts) {
+          continue;
+        }
+
+        for (let artifact of artifacts) {
+          if (artifact.endsWith(".exe")) {
+            artifact = artifact.substring(0, artifact.length - 4);
+          }
+
+          if (this.filenamesAreEqual(executable, artifact, workaround)) {
+            let name = target["name"];
+            if (name) {
+              // We found the target name
+              return name;
+            }
+          }
+        }
+      }
+    }
+
+    return undefined;
+  }
+
+  /// Returns whether the two filenames are equal
+  /// If workaround is true, then we workaround microsoft/vscode-cmake-tools-api/issues/7 where
+  /// the basename is correct but the path is bogus, and we only compare the basenames
+  filenamesAreEqual(
+    file1: string,
+    file2: string,
+    workaround: boolean = false,
+  ): boolean {
+    if (file1.endsWith(".exe")) {
+      file1 = file1.substring(0, file1.length - 4);
+    }
+
+    if (file2.endsWith(".exe")) {
+      file2 = file2.substring(0, file2.length - 4);
+    }
+
+    file1 = file1.replace(/\\/g, "/");
+    file2 = file2.replace(/\\/g, "/");
+
+    if (process.platform === "win32") {
+      file1 = file1.toLowerCase();
+      file2 = file2.toLowerCase();
+    }
+
+    if (file1 === file2) {
+      return true;
+    }
+
+    if (!workaround) {
+      // files aren't equal!
+      return false;
+    }
+
+    const fs = require("fs");
+    if (fs.existsSync(file2)) {
+      // It's a real file, not bogus.
+      return false;
+    }
+
+    /// Compare only basename, since path is bogus
+    return path.basename(file1, ".exe") === path.basename(file2, ".exe");
+  }
+
+  /// Returns the list of .cpp files for the specified executable
+  /// codemodel is the CMake codemodel JSON object
+  /// codemodel should have a "projects" key at root.
+  /// @param workaround If true, worksaround https://github.com/microsoft/vscode-cmake-tools-api/issues/7
+  public cppFilesForExecutable(
+    executable: string,
+    codemodel: any,
+    workaround: boolean = false,
+  ): string[] {
+    let projects = codemodel["projects"];
+    if (!projects) {
+      return [];
+    }
+
+    for (let project of projects) {
+      let targets = project["targets"];
+      if (!targets) {
+        continue;
+      }
+
+      for (let target of targets) {
+        let sourceDir = target["sourceDirectory"];
+        let artifacts = target["artifacts"];
+        if (!artifacts || !sourceDir) {
+          continue;
+        }
+
+        let targetType = target["type"];
+        if (targetType !== "EXECUTABLE") {
+          continue;
+        }
+
+        for (let artifact of artifacts) {
+          if (artifact.endsWith(".exe")) {
+            artifact = artifact.substring(0, artifact.length - 4);
+          }
+
+          // replace backslashes with forward slashes
+          artifact = artifact.replace(/\\/g, "/");
+
+          if (this.filenamesAreEqual(executable, artifact, workaround)) {
+            let fileGroups = target["fileGroups"];
+            if (!fileGroups) {
+              continue;
+            }
+
+            for (let fileGroup of fileGroups) {
+              if (fileGroup["language"] !== "CXX" || fileGroup["isGenerated"]) {
+                continue;
+              }
+
+              let sources = fileGroup["sources"];
+              if (!sources) {
+                continue;
+              }
+
+              let cppFiles: string[] = [];
+              for (let source of sources) {
+                if (!source.endsWith("mocs_compilation.cpp")) {
+                  cppFiles.push(path.join(sourceDir, source));
+                }
+              }
+
+              return cppFiles;
+            }
+          }
+        }
+      }
+    }
+
+    logMessage(
+      "cppFilesForExecutable: Could not find cpp files for executable " +
+        executable,
+    );
+    return [];
+  }
+}
+
+/// Represents an inividual CTest test
+export class CMakeTest {
+  public command: string[] = [];
+  public cwd: string = "";
+  public environment: string[] = [];
+
+  public id(): string {
+    return this.command.join(",");
+  }
+
+  public label(): string {
+    return path.basename(this.executablePath());
+  }
+
+  public executablePath(): string {
+    return this.command[0];
+  }
+}

--- a/src/qttest-utils/index.ts
+++ b/src/qttest-utils/index.ts
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// Author: Sergio Martins <sergio.martins@kdab.com>
+// SPDX-License-Identifier: MIT
+
+export { CMakeTests, CMakeTest } from "./cmake";
+export { QtTests, QtTest, QtTestSlot } from "./qttest";

--- a/src/qttest-utils/qttest.ts
+++ b/src/qttest-utils/qttest.ts
@@ -1,0 +1,604 @@
+// SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// Author: Sergio Martins <sergio.martins@kdab.com>
+// SPDX-License-Identifier: MIT
+
+import { spawn } from "child_process";
+import path from "path";
+import * as fs from "fs";
+import { CMakeTests } from "./cmake";
+import { Parser } from "tap-parser";
+
+type LoggerFunction = (arg: string) => void;
+var gLogFunction: LoggerFunction | undefined;
+
+export function logMessage(message: string) {
+  if (gLogFunction) {
+    gLogFunction(message);
+  }
+}
+
+/**
+ * Represents a single QtTest executable.
+ * Supports listing the individual test slots
+ */
+export class QtTest {
+  readonly filename: string;
+  readonly buildDirPath: string;
+
+  /// If true, will print more verbose output
+  verbose: boolean = false;
+
+  /// Allows vscode extensions to associate with a test item
+  vscodeTestItem: any | undefined;
+
+  /// The list of individual runnable test slots
+  slots: QtTestSlot[] | null = null;
+
+  /// Environment variables coming from CTest (array of "VAR=VALUE")
+  environment: string[] = [];
+
+  /// Set after running
+  lastExitCode: number = 0;
+
+  /// Allows the caller to receive the output of the test process
+  outputFunc: LoggerFunction | undefined = undefined;
+
+  constructor(filename: string, buildDirPath: string) {
+    this.filename = filename;
+    this.buildDirPath = buildDirPath;
+  }
+
+  public get id() {
+    return this.filename;
+  }
+
+  public get label() {
+    return path.basename(this.filename);
+  }
+
+  public relativeFilename() {
+    let result = path.relative(process.cwd(), this.filename);
+
+    // strip .exe, as we only use this for tests
+    if (result.endsWith(".exe")) {
+      result = result.slice(0, -4);
+    }
+
+    // normalize slashes
+    result = result.replace(/\\/g, "/");
+
+    return result;
+  }
+
+  /// returns filename without .exe extension
+  public filenameWithoutExtension() {
+    let result = this.filename;
+    if (result.endsWith(".exe")) {
+      result = result.slice(0, -4);
+    }
+
+    return result;
+  }
+
+  private buildSpawnEnv(): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = Object.assign({}, process.env);
+    if (this.environment && Array.isArray(this.environment)) {
+      for (const kv of this.environment) {
+        const idx = kv.indexOf("=");
+        if (idx > -1) {
+          env[kv.substring(0, idx)] = kv.substring(idx + 1);
+        }
+      }
+    }
+    return env;
+  }
+
+  /**
+   * Calls "./yourqttest -functions" and stores the results in the slots property.
+   */
+  public async parseAvailableSlots(): Promise<void> {
+    if (await this.isGTest()) {
+      logMessage(
+        "qttest: Skipping -functions for GTest executable: " + this.filename,
+      );
+      this.slots = [];
+      return;
+    }
+
+    let slotNames: string[] = [];
+    let output = "";
+    let err = "";
+
+    await new Promise((resolve, reject) => {
+      if (!fs.existsSync(this.filename)) {
+        reject(new Error("qttest: File doesn't exit: " + this.filename));
+        return;
+      }
+
+      const child = spawn(this.filename, ["-functions"], {
+        cwd: this.buildDirPath,
+        env: this.buildSpawnEnv(),
+      });
+
+      child.stdout.on("data", (chunk) => {
+        output += chunk.toString();
+      });
+
+      child.stderr.on("data", (chunk) => {
+        err += chunk.toString();
+      });
+
+      child.on("exit", (code) => {
+        if (code === 0) {
+          slotNames = slotNames.concat(output.split("\n"));
+          slotNames = slotNames.map((entry) => entry.trim().replace("()", ""));
+          slotNames = slotNames.filter((entry) => entry.length > 0);
+
+          if (slotNames.length > 0) {
+            this.slots = [];
+            for (var slotName of slotNames) {
+              var slot = new QtTestSlot(slotName, this);
+              this.slots.push(slot);
+            }
+          }
+
+          resolve(slotNames);
+        } else {
+          reject(
+            new Error(
+              "qttest: Failed to run -functions, stdout=" +
+                output +
+                "; stderr=" +
+                err +
+                "; code=" +
+                code,
+            ),
+          );
+        }
+      });
+    });
+  }
+
+  /**
+   * Returns whether this executable links to libQtTest.so.
+   *
+   * Useful for Qt autodetection, as some tests are doctest or so.
+   *
+   * Only implemented for Linux. Returns undefined on other platforms.
+   */
+  public linksToQtTestLib(): Promise<boolean> | undefined {
+    let isLinux = process.platform === "linux";
+    if (!isLinux) {
+      return undefined;
+    }
+
+    return new Promise((resolve, reject) => {
+      if (this.verbose) {
+        logMessage("qttest: Running ldd on " + this.filename);
+      }
+
+      const child = spawn("ldd", [this.filename]);
+      let output = "";
+      let result = false;
+      child.stdout.on("data", (chunk) => {
+        if (!result) {
+          if (
+            chunk.toString().includes("libQt5Test.so") ||
+            chunk.toString().includes("libQt6Test.so")
+          ) {
+            result = true;
+          }
+        }
+
+        if (this.verbose) {
+          logMessage(chunk.toString());
+        }
+      });
+
+      child.on("exit", (code) => {
+        if (code === 0) {
+          resolve(result);
+        } else {
+          reject(new Error("qttest: Failed to run ldd"));
+        }
+      });
+    });
+  }
+
+  /// Returns whether this test is a QtTest by running it with -help and checking if the help text looks familiar
+  /// Note that if this is not a QtTest it might not run help and instead execute the test itself
+  public async isQtTestViaHelp(): Promise<boolean | undefined> {
+    return await new Promise((resolve, reject) => {
+      const child = spawn(this.filename, ["-help"], {
+        env: this.buildSpawnEnv(),
+      });
+      let output = "";
+      let result = false;
+      child.stdout.on("data", (chunk) => {
+        if (!result) {
+          if (chunk.toString().includes("[testfunction[:testdata]]")) {
+            result = true;
+          }
+        }
+      });
+
+      child.on("exit", (code) => {
+        if (code === 0) {
+          resolve(result);
+        } else {
+          resolve(false);
+        }
+      });
+    });
+  }
+
+  /// Returns whether this executable is a Google Test by running it with --help
+  /// and checking if the output contains the GTest banner
+  public async isGTest(): Promise<boolean> {
+    return await new Promise((resolve) => {
+      if (!fs.existsSync(this.filename)) {
+        resolve(false);
+        return;
+      }
+
+      const child = spawn(this.filename, ["--help"], {
+        env: this.buildSpawnEnv(),
+      });
+      let output = "";
+      let found = false;
+      child.stdout.on("data", (chunk) => {
+        if (!found) {
+          if (
+            chunk
+              .toString()
+              .includes("This program contains tests written using Google Test")
+          ) {
+            found = true;
+          }
+        }
+      });
+
+      child.on("exit", () => {
+        resolve(found);
+      });
+    });
+  }
+
+  public slotByName(name: string): QtTestSlot | undefined {
+    if (!this.slots) {
+      return undefined;
+    }
+
+    for (let slot of this.slots) {
+      if (slot.name === name) {
+        return slot;
+      }
+    }
+
+    return undefined;
+  }
+
+  /// Runs this test
+  public async runTest(slot?: QtTestSlot, cwd: string = ""): Promise<boolean> {
+    let args: string[] = [];
+    if (slot) {
+      // Runs a single Qt test instead
+      args = args.concat(slot.name);
+    } else {
+      this.clearSubTestStates();
+    }
+
+    // log to file and to stdout
+    args = args.concat("-o").concat(this.tapOutputFileName(slot) + ",tap");
+    args = args.concat("-o").concat(this.txtOutputFileName(slot) + ",txt");
+    args = args.concat("-o").concat("-,txt");
+
+    return await new Promise((resolve, reject) => {
+      let cwdDir = cwd.length > 0 ? cwd : this.buildDirPath;
+      logMessage(
+        "Running " +
+          this.filename +
+          " " +
+          args.join(" ") +
+          " with cwd=" +
+          cwdDir,
+      );
+      const child = spawn(this.filename, args, {
+        cwd: cwdDir,
+        env: this.buildSpawnEnv(),
+      });
+
+      if (this.outputFunc) {
+        // Callers wants the process output:
+        child.stdout.on("data", (chunk) => {
+          if (this.outputFunc) {
+            this.outputFunc(chunk.toString());
+          }
+        });
+
+        child.stderr.on("data", (chunk) => {
+          if (this.outputFunc) {
+            this.outputFunc(chunk.toString());
+          }
+        });
+      }
+
+      child.on("exit", async (code) => {
+        /// Can code even be null ?
+        if (code === undefined || code === null) {
+          code = -1;
+        }
+
+        if (!slot) {
+          this.lastExitCode = code;
+        }
+
+        if (this.slots && this.slots.length > 0) {
+          /// When running a QtTest executable, let's check which sub-tests failed
+          /// (So VSCode can show some error icon for each fail)
+          try {
+            await this.updateSubTestStates(cwdDir, slot);
+          } catch (e) {
+            logMessage("Failed to update sub-test states: " + e);
+          }
+        }
+
+        if (code === 0) {
+          resolve(true);
+        } else {
+          resolve(false);
+        }
+      });
+    });
+  }
+
+  /// Using .tap so we don't have to use a separate XML library
+  /// .tap is plain text and a single regexp can catch the failing tests and line number
+  public tapOutputFileName(slot?: QtTestSlot): string {
+    let slotName = slot ? "_" + slot.name : "";
+    return this.label + slotName + ".tap";
+  }
+
+  public txtOutputFileName(slot?: QtTestSlot): string {
+    let slotName = slot ? "_" + slot.name : "";
+    return this.label + slotName + ".txt";
+  }
+
+  public command(): { label: string; executablePath: string; args: string[] } {
+    return { label: this.label, executablePath: this.filename, args: [] };
+  }
+
+  public clearSubTestStates() {
+    if (this.slots) {
+      for (let slot of this.slots) {
+        slot.lastTestFailure = undefined;
+      }
+    }
+  }
+
+  public async updateSubTestStates(cwdDir: string, slot?: QtTestSlot) {
+    let tapFileName: string = cwdDir + "/" + this.tapOutputFileName(slot);
+
+    var failures = await new Promise<TestFailure[]>((resolve, reject) => {
+      fs.readFile(tapFileName, "utf8", (error, data) => {
+        if (error) {
+          logMessage("ERROR: Failed to read log file");
+          reject(error);
+        } else {
+          let failedResults: TestFailure[] = [];
+
+          try {
+            const tapEvents = Parser.parse(data);
+            for (let event of tapEvents) {
+              try {
+                if (event.length < 2) {
+                  continue;
+                }
+                if (event.at(0) !== "assert") {
+                  continue;
+                }
+
+                var obj = event.at(1);
+                let pass = obj["ok"] === true;
+
+                let xfail = !pass && obj["todo"] !== false;
+                if (xfail) {
+                  // This is a QEXPECT_FAIL test, all good.
+                  // QtTest outputs it as "todo"
+                  continue;
+                }
+
+                // There's an QEXPECT_FAIL but test passed, not good.
+                let xpass =
+                  pass && obj["todo"].includes("returned TRUE unexpectedly");
+
+                if (!pass || xpass) {
+                  // We found a failure
+
+                  var name = obj["name"].replace(/\(.*\)/, "");
+                  var filename = "";
+                  var lineNumber = -1;
+
+                  if (obj["diag"]) {
+                    filename = obj["diag"]["file"];
+                    lineNumber = obj["diag"]["line"];
+                  } else {
+                    // A XPASS for example misses file:line info. Nothing we can do, it's a Qt bug arguably.
+                  }
+
+                  failedResults.push({
+                    name: name,
+                    filePath: filename,
+                    lineNumber: lineNumber,
+                  });
+                }
+              } catch (e) {}
+            }
+          } catch (e) {}
+
+          resolve(failedResults);
+        }
+      });
+    });
+
+    for (let failure of failures) {
+      if (slot && slot.name !== failure.name) {
+        // We executed a single slot, ignore anything else
+        continue;
+      }
+
+      let failedSlot = this.slotByName(failure.name);
+      if (failedSlot) {
+        failedSlot.lastTestFailure = failure;
+      } else {
+        logMessage("ERROR: Failed to find slot with name " + failure.name);
+      }
+    }
+  }
+}
+
+/**
+ * Represents a single Qt test slot
+ */
+export class QtTestSlot {
+  name: string;
+
+  // The QTest executable this slot belongs to
+  parentQTest: QtTest;
+
+  /// Allows vscode extensions to associate with a test item
+  vscodeTestItem: any | undefined;
+
+  /// Set after running
+  lastTestFailure: TestFailure | undefined;
+
+  constructor(name: string, parent: QtTest) {
+    this.name = name;
+    this.parentQTest = parent;
+  }
+
+  public get id() {
+    return this.parentQTest.filename + this.name;
+  }
+
+  public get absoluteFilePath() {
+    return this.parentQTest.filename;
+  }
+
+  public async runTest(): Promise<boolean> {
+    return this.parentQTest.runTest(this);
+  }
+
+  public command(): { label: string; executablePath: string; args: string[] } {
+    return {
+      label: this.name,
+      executablePath: this.absoluteFilePath,
+      args: [this.name],
+    };
+  }
+}
+
+/**
+ * Represents the list of all QtTest executables in your project
+ */
+export class QtTests {
+  qtTestExecutables: QtTest[] = [];
+
+  async discoverViaCMake(buildDirPath: string) {
+    var cmake = new CMakeTests(buildDirPath);
+    let ctests = await cmake.tests();
+    if (ctests) {
+      for (let ctest of ctests) {
+        let qtest = new QtTest(ctest.executablePath(), buildDirPath);
+        // Propagate environment from CTest metadata
+        qtest.environment = ctest.environment;
+        this.qtTestExecutables.push(qtest);
+      }
+    } else {
+      logMessage("ERROR: Failed to retrieve ctests!");
+    }
+  }
+
+  /// Removes any executable (from the list) that doesn't link to libQtTest.so
+  /// This heuristic tries to filter-out doctest and other non-Qt tests
+  /// Only implemented for linux for now
+  public async removeNonLinking() {
+    let isLinux = process.platform === "linux";
+    if (!isLinux) {
+      return;
+    }
+
+    let acceptedExecutables: QtTest[] = [];
+    for (let ex of this.qtTestExecutables) {
+      let linksToQt = await ex.linksToQtTestLib();
+      // undefined or true is accepted
+      if (linksToQt !== false) {
+        acceptedExecutables.push(ex);
+      }
+      this.qtTestExecutables = acceptedExecutables;
+    }
+  }
+
+  public setLogFunction(func: LoggerFunction) {
+    gLogFunction = func;
+  }
+
+  public async removeByRunningHelp() {
+    this.qtTestExecutables = this.qtTestExecutables.filter(
+      async (ex) => await ex.isQtTestViaHelp(),
+    );
+  }
+
+  /// Removes any executable (from the list) that matches the specified regex
+  public removeMatching(regex: RegExp) {
+    this.qtTestExecutables = this.qtTestExecutables.filter(
+      (ex) => !regex.test(ex.filename),
+    );
+  }
+
+  /// Removes any executable (from the list) that doesn't match the specified regex
+  public maintainMatching(regex: RegExp) {
+    this.qtTestExecutables = this.qtTestExecutables.filter((ex) =>
+      regex.test(ex.filename),
+    );
+  }
+
+  public dumpExecutablePaths() {
+    for (var ex of this.qtTestExecutables) {
+      console.log(ex.filename);
+    }
+  }
+
+  public async dumpTestSlots() {
+    for (var ex of this.qtTestExecutables) {
+      if (!ex.slots) {
+        await ex.parseAvailableSlots();
+      }
+
+      console.log(ex.filename);
+      if (ex.slots) {
+        for (let slot of ex.slots) {
+          console.log("    - " + slot.name);
+        }
+      }
+    }
+  }
+
+  /// Returns all executables that contain a Qt test slot with the specified name
+  public executablesContainingSlot(slotName: string): QtTest[] {
+    let result: QtTest[] = [];
+    for (let ex of this.qtTestExecutables) {
+      if (ex.slotByName(slotName)) {
+        result.push(ex);
+      }
+    }
+    return result;
+  }
+}
+
+/// Represents a failure location
+export interface TestFailure {
+  name: string;
+  filePath: string;
+  lineNumber: number;
+}

--- a/src/qttest-utils/test.ts
+++ b/src/qttest-utils/test.ts
@@ -1,0 +1,333 @@
+// SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// Author: Sergio Martins <sergio.martins@kdab.com>
+// SPDX-License-Identifier: MIT
+
+import { CMakeTests } from "./cmake";
+import { QtTest, QtTests } from "./qttest";
+
+// Be sure to build the Qt tests with CMake first
+// See .github/workflows/ci.yml
+
+async function runTests(buildDirPath: string) {
+  let qt = new QtTests();
+  await qt.discoverViaCMake(buildDirPath);
+
+  // Verify that environment properties from CTest were discovered for test1
+  const test1Exe = qt.qtTestExecutables.find((e) =>
+    e.filenameWithoutExtension().endsWith("test1"),
+  );
+  if (!test1Exe) {
+    console.error("Expected to find test1 executable after discovery");
+    process.exit(1);
+  }
+  if (!test1Exe.environment || !test1Exe.environment.includes("MY_ENV=VALUE")) {
+    console.error(
+      "Expected test1 to have environment MY_ENV=VALUE, got: " +
+        JSON.stringify(test1Exe.environment),
+    );
+    process.exit(1);
+  }
+
+  let expectedExecutables = [
+    "test/qt_test/build-dev/test1",
+    "test/qt_test/build-dev/test2",
+    "test/qt_test/build-dev/test3",
+    "test/qt_test/build-dev/non_qttest",
+    "test/qt_test/build-dev/test_gtest",
+    "test/qt_test/build-dev/nested_dir/test_nested",
+  ];
+
+  if (qt.qtTestExecutables.length !== expectedExecutables.length) {
+    console.error(
+      "Expected " +
+        expectedExecutables.length +
+        " executables, got " +
+        qt.qtTestExecutables.length,
+    );
+    process.exit(1);
+  }
+
+  // Verify that test_gtest is detected as a GTest
+  const gtestExe = qt.qtTestExecutables.find((e) =>
+    e.filenameWithoutExtension().endsWith("test_gtest"),
+  );
+  if (!gtestExe) {
+    console.error("Expected to find test_gtest executable after discovery");
+    process.exit(1);
+  }
+  if (!(await gtestExe.isGTest())) {
+    console.error("Expected test_gtest to be detected as a GTest");
+    process.exit(1);
+  }
+  console.log("PASS: test_gtest detected as GTest");
+
+  // Verify that test_gtest has no slots after parseAvailableSlots (GTest is skipped)
+  await gtestExe.parseAvailableSlots();
+  if (!gtestExe.slots || gtestExe.slots.length !== 0) {
+    console.error(
+      "Expected test_gtest to have 0 slots, got " +
+        (gtestExe.slots?.length ?? "null"),
+    );
+    process.exit(1);
+  }
+  console.log("PASS: test_gtest has 0 slots (no children)");
+
+  // Verify that a QtTest is not detected as a GTest
+  if (await test1Exe.isGTest()) {
+    console.error("Expected test1 to NOT be detected as a GTest");
+    process.exit(1);
+  }
+  console.log("PASS: test1 (QtTest) not misdetected as GTest");
+
+  await qt.removeNonLinking();
+
+  /// On macOS and Windows we don't have ldd or equivalent, so we can't check if the test links to QtTest
+  /// Use the help way instead
+  await qt.removeByRunningHelp();
+
+  /// Remove the non-qttest and gtest executables from qt.qtTestExecutables
+  qt.qtTestExecutables = qt.qtTestExecutables.filter(
+    (e) =>
+      !e.filenameWithoutExtension().endsWith("non_qttest") &&
+      !e.filenameWithoutExtension().endsWith("test_gtest"),
+  );
+
+  if (qt.qtTestExecutables.length !== 4) {
+    console.error(
+      "Expected 4 executables, at this point got " +
+        qt.qtTestExecutables.length,
+    );
+    process.exit(1);
+  }
+
+  // 1. Test that the executable test names are correct:
+  let expectedFilteredExecutables = [
+    "test/qt_test/build-dev/test1",
+    "test/qt_test/build-dev/test2",
+    "test/qt_test/build-dev/test3",
+    "test/qt_test/build-dev/nested_dir/test_nested",
+  ];
+  var i = 0;
+  for (var executable of qt.qtTestExecutables) {
+    let expected = expectedFilteredExecutables[i];
+    if (executable.relativeFilename() !== expected) {
+      console.error(
+        "Expected executable " +
+          expected +
+          ", got " +
+          executable.relativeFilename(),
+      );
+      process.exit(1);
+    }
+    i++;
+  }
+
+  // 2. Test that the discovered slots are correct:
+  await qt.dumpTestSlots();
+
+  interface ExpectedSlots {
+    [key: string]: string[];
+  }
+  let expectedSlots: ExpectedSlots = {
+    "test/qt_test/build-dev/test1": ["slotA", "slotB", "slotC"],
+    "test/qt_test/build-dev/test2": ["slotC", "slotD", "slotFail"],
+    "test/qt_test/build-dev/test3": ["slotFail2", "slotF", "slotG"],
+    "test/qt_test/build-dev/nested_dir/test_nested": [
+      "slotNested1",
+      "slotNested2",
+      "slotNested3",
+    ],
+  };
+
+  for (var executable of qt.qtTestExecutables) {
+    var i = 0;
+
+    for (let slot of executable.slots!) {
+      let expectedSlot = expectedSlots[executable.relativeFilename()][i];
+      if (slot.name !== expectedSlot) {
+        console.error("Expected slot " + expectedSlot + ", got " + slot.name);
+        process.exit(1);
+      }
+      i++;
+    }
+  }
+
+  // 3. Run the tests:
+  let expectedSuccess = [true, false, false, true];
+  var i = 0;
+  for (var executable of qt.qtTestExecutables) {
+    await executable.runTest();
+    let wasSuccess = executable.lastExitCode === 0;
+    if (wasSuccess && !expectedSuccess[i]) {
+      console.error("Expected test to fail: " + executable.filename);
+      process.exit(1);
+    } else if (!wasSuccess && expectedSuccess[i]) {
+      console.error("Expected test to pass: " + executable.filename);
+      process.exit(1);
+    }
+
+    if (process.platform === "linux") {
+      if (!executable.linksToQtTestLib()) {
+        console.error(
+          "Expected test to link to QtTest: " + executable.filename,
+        );
+        process.exit(1);
+      }
+    }
+
+    i++;
+  }
+
+  // 4. Run individual slots:
+  // Run a passing slot (slotA from test1)
+  let slot = qt.qtTestExecutables[0].slots![0];
+  await slot.runTest();
+  if (slot.lastTestFailure) {
+    console.error("Expected test to pass: " + slot.name);
+    process.exit(1);
+  }
+
+  // Run a failing slot (slotFail from test2)
+  let slot2 = qt.qtTestExecutables[1].slots![2];
+  await slot2.runTest();
+  if (!slot2.lastTestFailure) {
+    console.error("Expected test to fail: " + slot2.name);
+    process.exit(1);
+  }
+
+  // 5. Test executablesContainingSlot
+  let executables = qt.executablesContainingSlot("slotB");
+  if (executables.length !== 1) {
+    console.error("Expected 1 executable, got " + executables.length);
+    process.exit(1);
+  }
+
+  if (!executables[0].filenameWithoutExtension().endsWith("test1")) {
+    console.error("Expected filename to end with test1");
+    process.exit(1);
+  }
+
+  executables = qt.executablesContainingSlot("non_existing");
+  if (executables.length !== 0) {
+    console.error("Expected 0 executables, got " + executables.length);
+    process.exit(1);
+  }
+}
+
+async function runCodeModelTests(codeModelFile: string) {
+  const fs = require("fs");
+  let codemodelStr = fs.readFileSync(codeModelFile, "utf8");
+  let codemodelJson = JSON.parse(codemodelStr);
+
+  let cmake = new CMakeTests("random");
+  let files = cmake.cppFilesForExecutable(
+    "/vscode-qttest/test/qt_test/build-dev/test1",
+    codemodelJson,
+  );
+  if (files.length !== 1) {
+    console.error("Expected 1 file, got " + files.length);
+    process.exit(1);
+  }
+
+  let expected = "/vscode-qttest/test/qt_test/test1.cpp";
+  let got = files[0].replace(/\\/g, "/");
+
+  if (got !== expected) {
+    console.error("Expected " + expected + ", got " + got);
+    process.exit(1);
+  }
+
+  let targetName = cmake.targetNameForExecutable(
+    "/vscode-qttest/test/qt_test/build-dev/test1",
+    codemodelJson,
+  );
+  if (targetName !== "test1") {
+    console.error("Expected test1, got " + targetName);
+    process.exit(1);
+  }
+
+  // test windows back slashes:
+
+  files = cmake.cppFilesForExecutable(
+    "/vscode-qttest/test/qt_test/build-dev/test2",
+    codemodelJson,
+  );
+  if (files.length !== 1) {
+    console.error("Expected 1 file, got " + files.length);
+    process.exit(1);
+  }
+
+  targetName = cmake.targetNameForExecutable(
+    "/vscode-qttest/test/qt_test/build-dev/test2",
+    codemodelJson,
+  );
+  if (targetName !== "test2") {
+    console.error("Expected test2, got " + targetName);
+    process.exit(1);
+  }
+
+  // test workaround for microsoft/vscode-cmake-tools-api/issues/7
+  files = cmake.cppFilesForExecutable(
+    "/vscode-qttest/test/qt_test/build-dev/test3",
+    codemodelJson,
+    /*workaround=*/ false,
+  );
+  if (files.length !== 0) {
+    console.error("Expected 0 files, got " + files.length);
+    process.exit(1);
+  }
+
+  files = cmake.cppFilesForExecutable(
+    "/vscode-qttest/test/qt_test/build-dev/test3",
+    codemodelJson,
+    /*workaround=*/ true,
+  );
+  if (files.length !== 1) {
+    console.error("Expected 0 files, got " + files.length);
+    process.exit(1);
+  }
+
+  targetName = cmake.targetNameForExecutable(
+    "/vscode-qttest/test/qt_test/build-dev/test3",
+    codemodelJson,
+    /*workaround=*/ false,
+  );
+  if (targetName) {
+    console.error("Expected null, got " + targetName);
+    process.exit(1);
+  }
+
+  targetName = cmake.targetNameForExecutable(
+    "/vscode-qttest/test/qt_test/build-dev/test3",
+    codemodelJson,
+    /*workaround=*/ true,
+  );
+  if (targetName !== "test3") {
+    console.error("Expected null, got " + targetName);
+    process.exit(1);
+  }
+}
+
+async function runNonQtTest(buildDirPath: string) {
+  let qt = new QtTests();
+  await qt.discoverViaCMake(buildDirPath);
+
+  var nonQtExecutable = undefined;
+  for (let executable of qt.qtTestExecutables) {
+    if (executable.filenameWithoutExtension().endsWith("non_qttest")) {
+      nonQtExecutable = executable;
+      break;
+    }
+  }
+
+  if (nonQtExecutable === undefined) {
+    console.error("Expected to find non-Qt test executable");
+    process.exit(1);
+  }
+
+  await nonQtExecutable.runTest();
+}
+
+runTests("test/qt_test/build-dev/");
+runNonQtTest("test/qt_test/build-dev/");
+runCodeModelTests("test/test_cmake_codemodel.json");

--- a/src/qttest-utils/tsconfig.test.json
+++ b/src/qttest-utils/tsconfig.test.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2022",
+    "outDir": "../../out/qttest-utils",
+    "rootDir": ".",
+    "esModuleInterop": true,
+    "strict": true,
+    "moduleResolution": "node10",
+    "ignoreDeprecations": "6.0",
+    "types": ["node"]
+  },
+  "files": ["test.ts"]
+}

--- a/src/qttest-utils/utils.ts
+++ b/src/qttest-utils/utils.ts
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// Author: Sergio Martins <sergio.martins@kdab.com>
+// SPDX-License-Identifier: MIT
+
+import path from "path";
+import * as fs from "fs";
+
+/// Returns whether the specified file is an executable
+function isExecutable(filePath: string): boolean {
+  if (process.platform === "win32") {
+    return path.extname(filePath).toLocaleLowerCase() === ".exe";
+  } else {
+    try {
+      fs.accessSync(filePath, fs.constants.X_OK);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
+}
+
+/// Returns whether the specified file is a library
+function isLibrary(filename: string): boolean {
+  const split = filename.split(".");
+
+  if (split.length <= 1) {
+    return false;
+  }
+
+  // Find the first non-numeric extension, so we ignore all the trailing numbers in libFoo.so.2.0.9
+  for (var i = split.length - 1; i >= 0; --i) {
+    const extension = split[i];
+    const isNumber = !isNaN(Number(extension));
+    if (isNumber) {
+      continue;
+    }
+
+    return ["so", "dll", "dylib"].includes(extension);
+  }
+
+  return false;
+}
+
+/// Recursively looks for executable files in folderPath
+function executableFiles(folderPath: string): string[] {
+  const files = fs.readdirSync(folderPath);
+  var executables: string[] = [];
+  for (var file of files) {
+    // Ignore CMakeFiles directory, it has some of binaries
+    if (path.basename(file) === "CMakeFiles") {
+      continue;
+    }
+
+    const childPath = path.join(folderPath, file);
+    const info = fs.statSync(childPath);
+    if (info.isDirectory()) {
+      executables = executables.concat(executableFiles(childPath));
+    } else if (
+      info.isFile() &&
+      !isLibrary(path.basename(childPath)) &&
+      isExecutable(childPath)
+    ) {
+      executables.push(childPath);
+    }
+  }
+
+  return executables;
+}

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
+set -e
+
 cmake -S test/qt_test --preset=dev
 cmake --build test/qt_test/build-dev --verbose
+
+# qttest-utils unit tests
+./test_qttest.sh
 
 # This implicitly calls tsc and launches directly from out/,
 # no need to package

--- a/test/test_cmake_codemodel.json
+++ b/test/test_cmake_codemodel.json
@@ -1,0 +1,356 @@
+{
+    "name": "Debug",
+    "projects": [
+        {
+            "name": "qttest",
+            "targets": [
+                {
+                    "name": "non_qttest",
+                    "type": "EXECUTABLE",
+                    "sourceDirectory": "/vscode-qttest/test/qt_test",
+                    "fullName": "non_qttest",
+                    "artifacts": [
+                        "/vscode-qttest/test/qt_test/build-dev/non_qttest"
+                    ],
+                    "fileGroups": [
+                        {
+                            "isGenerated": false,
+                            "sources": [
+                                "build-dev/non_qttest_autogen/mocs_compilation.cpp",
+                                "non_qttest.cpp"
+                            ],
+                            "language": "CXX",
+                            "includePath": [
+                                {
+                                    "backtrace": 0,
+                                    "path": "/vscode-qttest/test/qt_test/build-dev/non_qttest_autogen/include"
+                                }
+                            ],
+                            "compileCommandFragments": [
+                                "-g"
+                            ],
+                            "defines": []
+                        },
+                        {
+                            "sources": [
+                                "build-dev/non_qttest_autogen/timestamp",
+                                "build-dev/non_qttest_autogen/timestamp.rule"
+                            ],
+                            "isGenerated": true
+                        }
+                    ]
+                },
+                {
+                    "name": "non_qttest_autogen",
+                    "type": "UTILITY",
+                    "sourceDirectory": "/vscode-qttest/test/qt_test",
+                    "artifacts": [],
+                    "fileGroups": [
+                        {
+                            "sources": [
+                                "build-dev/CMakeFiles/non_qttest_autogen",
+                                "build-dev/CMakeFiles/non_qttest_autogen.rule",
+                                "build-dev/non_qttest_autogen/timestamp.rule"
+                            ],
+                            "isGenerated": true
+                        }
+                    ]
+                },
+                {
+                    "name": "non_qttest_autogen_timestamp_deps",
+                    "type": "UTILITY",
+                    "sourceDirectory": "/vscode-qttest/test/qt_test",
+                    "artifacts": [],
+                    "fileGroups": [
+                        {
+                            "sources": [
+                                "build-dev/CMakeFiles/non_qttest_autogen_timestamp_deps",
+                                "build-dev/CMakeFiles/non_qttest_autogen_timestamp_deps.rule"
+                            ],
+                            "isGenerated": true
+                        }
+                    ]
+                },
+                {
+                    "name": "test1",
+                    "type": "EXECUTABLE",
+                    "sourceDirectory": "/vscode-qttest/test/qt_test",
+                    "fullName": "test1",
+                    "artifacts": [
+                        "/vscode-qttest/test/qt_test/build-dev/test1"
+                    ],
+                    "fileGroups": [
+                        {
+                            "isGenerated": false,
+                            "sources": [
+                                "build-dev/test1_autogen/mocs_compilation.cpp",
+                                "test1.cpp"
+                            ],
+                            "language": "CXX",
+                            "includePath": [
+                                {
+                                    "backtrace": 0,
+                                    "path": "/vscode-qttest/test/qt_test/build-dev/test1_autogen/include"
+                                },
+                                {
+                                    "backtrace": 2,
+                                    "isSystem": true,
+                                    "path": "/usr/include/x86_64-linux-gnu/qt5"
+                                },
+                                {
+                                    "backtrace": 2,
+                                    "isSystem": true,
+                                    "path": "/usr/include/x86_64-linux-gnu/qt5/QtTest"
+                                },
+                                {
+                                    "backtrace": 2,
+                                    "isSystem": true,
+                                    "path": "/usr/include/x86_64-linux-gnu/qt5/QtCore"
+                                },
+                                {
+                                    "backtrace": 2,
+                                    "isSystem": true,
+                                    "path": "/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++"
+                                }
+                            ],
+                            "compileCommandFragments": [
+                                "-g",
+                                "-fPIC"
+                            ],
+                            "defines": [
+                                "QT_CORE_LIB",
+                                "QT_TESTCASE_BUILDDIR=\"/vscode-qttest/test/qt_test/build-dev\"",
+                                "QT_TESTLIB_LIB"
+                            ]
+                        },
+                        {
+                            "sources": [
+                                "build-dev/test1_autogen/timestamp",
+                                "build-dev/test1_autogen/timestamp.rule"
+                            ],
+                            "isGenerated": true
+                        }
+                    ]
+                },
+                {
+                    "name": "test1_autogen",
+                    "type": "UTILITY",
+                    "sourceDirectory": "/vscode-qttest/test/qt_test",
+                    "artifacts": [],
+                    "fileGroups": [
+                        {
+                            "sources": [
+                                "build-dev/CMakeFiles/test1_autogen",
+                                "build-dev/CMakeFiles/test1_autogen.rule",
+                                "build-dev/test1_autogen/timestamp.rule"
+                            ],
+                            "isGenerated": true
+                        }
+                    ]
+                },
+                {
+                    "name": "test1_autogen_timestamp_deps",
+                    "type": "UTILITY",
+                    "sourceDirectory": "/vscode-qttest/test/qt_test",
+                    "artifacts": [],
+                    "fileGroups": [
+                        {
+                            "sources": [
+                                "build-dev/CMakeFiles/test1_autogen_timestamp_deps",
+                                "build-dev/CMakeFiles/test1_autogen_timestamp_deps.rule"
+                            ],
+                            "isGenerated": true
+                        }
+                    ]
+                },
+                {
+                    "name": "test2",
+                    "type": "EXECUTABLE",
+                    "sourceDirectory": "/vscode-qttest/test/qt_test",
+                    "fullName": "test2",
+                    "description": "test for windows",
+                    "artifacts": [
+                        "/vscode-qttest\\test\\qt_test\\build-dev\\test2.exe"
+                    ],
+                    "fileGroups": [
+                        {
+                            "isGenerated": false,
+                            "sources": [
+                                "build-dev/test2_autogen/mocs_compilation.cpp",
+                                "test2.cpp"
+                            ],
+                            "language": "CXX",
+                            "includePath": [
+                                {
+                                    "backtrace": 0,
+                                    "path": "/vscode-qttest/test/qt_test/build-dev/test2_autogen/include"
+                                },
+                                {
+                                    "backtrace": 2,
+                                    "isSystem": true,
+                                    "path": "/usr/include/x86_64-linux-gnu/qt5"
+                                },
+                                {
+                                    "backtrace": 2,
+                                    "isSystem": true,
+                                    "path": "/usr/include/x86_64-linux-gnu/qt5/QtTest"
+                                },
+                                {
+                                    "backtrace": 2,
+                                    "isSystem": true,
+                                    "path": "/usr/include/x86_64-linux-gnu/qt5/QtCore"
+                                },
+                                {
+                                    "backtrace": 2,
+                                    "isSystem": true,
+                                    "path": "/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++"
+                                }
+                            ],
+                            "compileCommandFragments": [
+                                "-g",
+                                "-fPIC"
+                            ],
+                            "defines": [
+                                "QT_CORE_LIB",
+                                "QT_TESTCASE_BUILDDIR=\"/vscode-qttest/test/qt_test/build-dev\"",
+                                "QT_TESTLIB_LIB"
+                            ]
+                        },
+                        {
+                            "sources": [
+                                "build-dev/test2_autogen/timestamp",
+                                "build-dev/test2_autogen/timestamp.rule"
+                            ],
+                            "isGenerated": true
+                        }
+                    ]
+                },
+                {
+                    "name": "test2_autogen",
+                    "type": "UTILITY",
+                    "sourceDirectory": "/vscode-qttest/test/qt_test",
+                    "artifacts": [],
+                    "fileGroups": [
+                        {
+                            "sources": [
+                                "build-dev/CMakeFiles/test2_autogen",
+                                "build-dev/CMakeFiles/test2_autogen.rule",
+                                "build-dev/test2_autogen/timestamp.rule"
+                            ],
+                            "isGenerated": true
+                        }
+                    ]
+                },
+                {
+                    "name": "test2_autogen_timestamp_deps",
+                    "type": "UTILITY",
+                    "sourceDirectory": "/vscode-qttest/test/qt_test",
+                    "artifacts": [],
+                    "fileGroups": [
+                        {
+                            "sources": [
+                                "build-dev/CMakeFiles/test2_autogen_timestamp_deps",
+                                "build-dev/CMakeFiles/test2_autogen_timestamp_deps.rule"
+                            ],
+                            "isGenerated": true
+                        }
+                    ]
+                },
+                {
+                    "name": "test3",
+                    "type": "EXECUTABLE",
+                    "sourceDirectory": "/vscode-qttest/test/qt_test",
+                    "fullName": "test3",
+                    "description": "buggy artifact path on purpose",
+                    "artifacts": [
+                        "/vscode-qttest/test/qt_test/build-dev/test/bin/test3"
+                    ],
+                    "fileGroups": [
+                        {
+                            "isGenerated": false,
+                            "sources": [
+                                "build-dev/test3_autogen/mocs_compilation.cpp",
+                                "test3.cpp"
+                            ],
+                            "language": "CXX",
+                            "includePath": [
+                                {
+                                    "backtrace": 0,
+                                    "path": "/vscode-qttest/test/qt_test/build-dev/test3_autogen/include"
+                                },
+                                {
+                                    "backtrace": 2,
+                                    "isSystem": true,
+                                    "path": "/usr/include/x86_64-linux-gnu/qt5"
+                                },
+                                {
+                                    "backtrace": 2,
+                                    "isSystem": true,
+                                    "path": "/usr/include/x86_64-linux-gnu/qt5/QtTest"
+                                },
+                                {
+                                    "backtrace": 2,
+                                    "isSystem": true,
+                                    "path": "/usr/include/x86_64-linux-gnu/qt5/QtCore"
+                                },
+                                {
+                                    "backtrace": 2,
+                                    "isSystem": true,
+                                    "path": "/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++"
+                                }
+                            ],
+                            "compileCommandFragments": [
+                                "-g",
+                                "-fPIC"
+                            ],
+                            "defines": [
+                                "QT_CORE_LIB",
+                                "QT_TESTCASE_BUILDDIR=\"/vscode-qttest/test/qt_test/build-dev\"",
+                                "QT_TESTLIB_LIB"
+                            ]
+                        },
+                        {
+                            "sources": [
+                                "build-dev/test3_autogen/timestamp",
+                                "build-dev/test3_autogen/timestamp.rule"
+                            ],
+                            "isGenerated": true
+                        }
+                    ]
+                },
+                {
+                    "name": "test3_autogen",
+                    "type": "UTILITY",
+                    "sourceDirectory": "/vscode-qttest/test/qt_test",
+                    "artifacts": [],
+                    "fileGroups": [
+                        {
+                            "sources": [
+                                "build-dev/CMakeFiles/test3_autogen",
+                                "build-dev/CMakeFiles/test3_autogen.rule",
+                                "build-dev/test3_autogen/timestamp.rule"
+                            ],
+                            "isGenerated": true
+                        }
+                    ]
+                },
+                {
+                    "name": "test3_autogen_timestamp_deps",
+                    "type": "UTILITY",
+                    "sourceDirectory": "/vscode-qttest/test/qt_test",
+                    "artifacts": [],
+                    "fileGroups": [
+                        {
+                            "sources": [
+                                "build-dev/CMakeFiles/test3_autogen_timestamp_deps",
+                                "build-dev/CMakeFiles/test3_autogen_timestamp_deps.rule"
+                            ],
+                            "isGenerated": true
+                        }
+                    ]
+                }
+            ],
+            "sourceDirectory": "/vscode-qttest/test/qt_test"
+        }
+    ]
+}

--- a/test_qttest.sh
+++ b/test_qttest.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Runs the qttest-utils unit tests.
+# Expects Qt test fixtures to be already built (test/qt_test/build-dev/).
+
+set -e
+
+cd "$(dirname "$0")"
+
+# Build qttest-utils into out/qttest-utils/
+npm run compile
+
+# Compile the test file (excluded from main tsconfig)
+npx tsc -p src/qttest-utils/tsconfig.test.json
+
+node out/qttest-utils/test.js

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
 		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
 	},
 	"exclude": [
-		"src/test/**/*"
+		"src/test/**/*",
+		"src/qttest-utils/test.ts"
 	]
 }


### PR DESCRIPTION
This simplifies development, no more roundtrips to npm.