### PR TITLE
feat: add script-file guards to skip execution of .sh/.bat test files

### DIFF
--- a/src/qttest-utils/cmake.ts
+++ b/src/qttest-utils/cmake.ts
@@ -123,7 +123,7 @@ export class CMakeTests {
       } catch (e) {
         try {
           logMessage(
-            "ctest: failed to parse environment for test: " +
+            "ERROR: ctest: failed to parse environment for test: " +
               JSON.stringify(testJSON) +
               " error: " +
               e,

--- a/src/qttest-utils/qttest.ts
+++ b/src/qttest-utils/qttest.ts
@@ -48,6 +48,11 @@ export class QtTest {
     this.buildDirPath = buildDirPath;
   }
 
+  private isScriptFile(): boolean {
+    const ext = path.extname(this.filename).toLowerCase();
+    return ext === ".sh" || ext === ".bat";
+  }
+
   public get id() {
     return this.filename;
   }
@@ -97,6 +102,10 @@ export class QtTest {
    * Calls "./yourqttest -functions" and stores the results in the slots property.
    */
   public async parseAvailableSlots(): Promise<void> {
+    if (this.isScriptFile()) {
+      this.slots = [];
+      return;
+    }
     if (await this.isGTest()) {
       logMessage(
         "qttest: Skipping -functions for GTest executable: " + this.filename,
@@ -167,6 +176,10 @@ export class QtTest {
    * Only implemented for Linux. Returns undefined on other platforms.
    */
   public linksToQtTestLib(): Promise<boolean> | undefined {
+    if (this.isScriptFile()) {
+      return Promise.resolve(false);
+    }
+
     let isLinux = process.platform === "linux";
     if (!isLinux) {
       return undefined;
@@ -208,6 +221,9 @@ export class QtTest {
   /// Returns whether this test is a QtTest by running it with -help and checking if the help text looks familiar
   /// Note that if this is not a QtTest it might not run help and instead execute the test itself
   public async isQtTestViaHelp(): Promise<boolean | undefined> {
+    if (this.isScriptFile()) {
+      return false;
+    }
     return await new Promise((resolve, reject) => {
       const child = spawn(this.filename, ["-help"], {
         env: this.buildSpawnEnv(),
@@ -235,6 +251,9 @@ export class QtTest {
   /// Returns whether this executable is a Google Test by running it with --help
   /// and checking if the output contains the GTest banner
   public async isGTest(): Promise<boolean> {
+    if (this.isScriptFile()) {
+      return false;
+    }
     return await new Promise((resolve) => {
       if (!fs.existsSync(this.filename)) {
         resolve(false);
@@ -339,7 +358,7 @@ export class QtTest {
           try {
             await this.updateSubTestStates(cwdDir, slot);
           } catch (e) {
-            logMessage("Failed to update sub-test states: " + e);
+            logMessage("ERROR: Failed to update sub-test states: " + e);
           }
         }
 
@@ -544,9 +563,14 @@ export class QtTests {
   }
 
   public async removeByRunningHelp() {
-    this.qtTestExecutables = this.qtTestExecutables.filter(
-      async (ex) => await ex.isQtTestViaHelp(),
-    );
+    let acceptedExecutables: QtTest[] = [];
+    for (const ex of this.qtTestExecutables) {
+      const isQtTest = await ex.isQtTestViaHelp();
+      if (isQtTest !== false) {
+        acceptedExecutables.push(ex);
+      }
+    }
+    this.qtTestExecutables = acceptedExecutables;
   }
 
   /// Removes any executable (from the list) that matches the specified regex

--- a/src/qttest-utils/test.ts
+++ b/src/qttest-utils/test.ts
@@ -2,6 +2,8 @@
 // Author: Sergio Martins <sergio.martins@kdab.com>
 // SPDX-License-Identifier: MIT
 
+import * as fs from "fs";
+import path from "path";
 import { CMakeTests } from "./cmake";
 import { QtTest, QtTests } from "./qttest";
 
@@ -11,6 +13,31 @@ import { QtTest, QtTests } from "./qttest";
 async function runTests(buildDirPath: string) {
   let qt = new QtTests();
   await qt.discoverViaCMake(buildDirPath);
+
+  const fooPath = path.resolve("test/qt_test/foo");
+  if (fs.existsSync(fooPath)) {
+    fs.unlinkSync(fooPath);
+  }
+
+  const shTest = new QtTest("test/qt_test/test.sh", "test/qt_test/");
+  if ((await shTest.isQtTestViaHelp()) !== false) {
+    console.error("FAIL: isQtTestViaHelp should return false for .sh");
+    process.exit(1);
+  }
+  if ((await shTest.isGTest()) !== false) {
+    console.error("FAIL: isGTest should return false for .sh");
+    process.exit(1);
+  }
+  await shTest.parseAvailableSlots();
+  if (!shTest.slots || shTest.slots.length !== 0) {
+    console.error("FAIL: parseAvailableSlots should yield 0 slots for .sh");
+    process.exit(1);
+  }
+  if (fs.existsSync(fooPath)) {
+    console.error("FAIL: a guard executed test.sh (foo exists)");
+    process.exit(1);
+  }
+  console.log("PASS: direct guard checks for .sh skip execution");
 
   // Verify that environment properties from CTest were discovered for test1
   const test1Exe = qt.qtTestExecutables.find((e) =>
@@ -27,6 +54,7 @@ async function runTests(buildDirPath: string) {
     );
     process.exit(1);
   }
+  console.log("PASS: test1 has expected environment");
 
   let expectedExecutables = [
     "test/qt_test/build-dev/test1",
@@ -34,6 +62,7 @@ async function runTests(buildDirPath: string) {
     "test/qt_test/build-dev/test3",
     "test/qt_test/build-dev/non_qttest",
     "test/qt_test/build-dev/test_gtest",
+    "test/qt_test/test.sh",
     "test/qt_test/build-dev/nested_dir/test_nested",
   ];
 
@@ -46,6 +75,9 @@ async function runTests(buildDirPath: string) {
     );
     process.exit(1);
   }
+  console.log(
+    "PASS: discovered " + expectedExecutables.length + " executables",
+  );
 
   // Verify that test_gtest is detected as a GTest
   const gtestExe = qt.qtTestExecutables.find((e) =>
@@ -85,11 +117,12 @@ async function runTests(buildDirPath: string) {
   /// Use the help way instead
   await qt.removeByRunningHelp();
 
-  /// Remove the non-qttest and gtest executables from qt.qtTestExecutables
+  /// Remove the non-qttest, gtest, and script executables from qt.qtTestExecutables
   qt.qtTestExecutables = qt.qtTestExecutables.filter(
     (e) =>
       !e.filenameWithoutExtension().endsWith("non_qttest") &&
-      !e.filenameWithoutExtension().endsWith("test_gtest"),
+      !e.filenameWithoutExtension().endsWith("test_gtest") &&
+      !e.filename.endsWith("test.sh"),
   );
 
   if (qt.qtTestExecutables.length !== 4) {
@@ -99,6 +132,7 @@ async function runTests(buildDirPath: string) {
     );
     process.exit(1);
   }
+  console.log("PASS: 4 Qt executables remain after filtering");
 
   // 1. Test that the executable test names are correct:
   let expectedFilteredExecutables = [
@@ -124,6 +158,12 @@ async function runTests(buildDirPath: string) {
 
   // 2. Test that the discovered slots are correct:
   await qt.dumpTestSlots();
+
+  if (fs.existsSync(fooPath)) {
+    console.error("FAIL: test.sh was executed during discovery (foo exists)");
+    process.exit(1);
+  }
+  console.log("PASS: test.sh was not executed during discovery");
 
   interface ExpectedSlots {
     [key: string]: string[];
@@ -151,6 +191,7 @@ async function runTests(buildDirPath: string) {
       i++;
     }
   }
+  console.log("PASS: all slot names are correct");
 
   // 3. Run the tests:
   let expectedSuccess = [true, false, false, true];
@@ -167,7 +208,7 @@ async function runTests(buildDirPath: string) {
     }
 
     if (process.platform === "linux") {
-      if (!executable.linksToQtTestLib()) {
+      if (!(await executable.linksToQtTestLib())) {
         console.error(
           "Expected test to link to QtTest: " + executable.filename,
         );
@@ -177,6 +218,7 @@ async function runTests(buildDirPath: string) {
 
     i++;
   }
+  console.log("PASS: test pass/fail outcomes are correct");
 
   // 4. Run individual slots:
   // Run a passing slot (slotA from test1)
@@ -194,6 +236,7 @@ async function runTests(buildDirPath: string) {
     console.error("Expected test to fail: " + slot2.name);
     process.exit(1);
   }
+  console.log("PASS: individual slot pass/fail outcomes are correct");
 
   // 5. Test executablesContainingSlot
   let executables = qt.executablesContainingSlot("slotB");
@@ -212,6 +255,7 @@ async function runTests(buildDirPath: string) {
     console.error("Expected 0 executables, got " + executables.length);
     process.exit(1);
   }
+  console.log("PASS: executablesContainingSlot works correctly");
 }
 
 async function runCodeModelTests(codeModelFile: string) {

--- a/test/qt_test/CMakeLists.txt
+++ b/test/qt_test/CMakeLists.txt
@@ -28,5 +28,6 @@ find_package(GTest REQUIRED)
 add_executable(test_gtest test_gtest.cpp)
 target_link_libraries(test_gtest GTest::GTest GTest::Main)
 add_test(NAME test_gtest COMMAND test_gtest)
+add_test(NAME script_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test.sh)
 
 add_subdirectory(nested_dir)

--- a/test/qt_test/test.sh
+++ b/test/qt_test/test.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+touch "$(dirname "$0")/foo"


### PR DESCRIPTION
Add isScriptFile() helper on QtTest and early-return guards in parseAvailableSlots, linksToQtTestLib, isQtTestViaHelp, and isGTest so shell/batch scripts discovered via CTest are never accidentally executed during slot enumeration or filtering. Fix removeByRunningHelp to use an awaited for-of loop instead of broken filter(async). Add test.sh fixture and script_test to CMakeLists.txt; extend integration test to assert the guards short-circuit and that foo is never created.